### PR TITLE
Improve survey dashboard UI with cards

### DIFF
--- a/app/Http/Controllers/SurveyController.php
+++ b/app/Http/Controllers/SurveyController.php
@@ -11,7 +11,10 @@ use Symfony\Component\HttpFoundation\StreamedResponse;
 class SurveyController extends Controller
 {
     public function index() {
-        $surveys = Survey::latest()->select('id','title','slug','status','version','published_at','created_at')->get();
+        $surveys = Survey::select('id','title','slug','status','version','published_at','created_at')
+            ->withCount('responses')
+            ->latest()
+            ->get();
         return Inertia::render('Surveys/Index', compact('surveys'));
     }
 

--- a/resources/js/components/survey-card.tsx
+++ b/resources/js/components/survey-card.tsx
@@ -1,0 +1,53 @@
+import { Link } from "@inertiajs/react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardHeader, CardTitle, CardDescription, CardContent, CardFooter } from "@/components/ui/card";
+
+declare function route(name: string, params?: unknown): string;
+
+type SurveyCardProps = {
+  survey: {
+    id: number;
+    title: string;
+    slug: string;
+    status: "draft" | "published";
+    version: number;
+    responses_count: number;
+  };
+};
+
+export function SurveyCard({ survey }: SurveyCardProps) {
+  const statusVariant = survey.status === "published" ? "default" : "secondary";
+  return (
+    <Card>
+      <CardHeader className="flex flex-row justify-between gap-2">
+        <div>
+          <CardTitle className="text-base">{survey.title}</CardTitle>
+          <CardDescription>/{survey.slug}</CardDescription>
+        </div>
+        <Badge variant={statusVariant} className="capitalize">
+          {survey.status}
+        </Badge>
+      </CardHeader>
+      <CardContent className="flex justify-between text-sm text-muted-foreground">
+        <div>Versi {survey.version}</div>
+        <div>{survey.responses_count} respons</div>
+      </CardContent>
+      <CardFooter className="justify-end gap-2">
+        <Button asChild variant="outline" size="sm">
+          <Link href={route("surveys.edit", survey.id)}>Edit</Link>
+        </Button>
+        <Button asChild variant="outline" size="sm">
+          <Link href={route("surveys.responses", survey.id)}>Responses</Link>
+        </Button>
+        {survey.status === "published" && (
+          <Button asChild variant="link" size="sm">
+            <a href={route("run.show", survey.slug)} target="_blank" rel="noopener noreferrer">
+              Open
+            </a>
+          </Button>
+        )}
+      </CardFooter>
+    </Card>
+  );
+}

--- a/resources/js/layouts/AdminLayout.tsx
+++ b/resources/js/layouts/AdminLayout.tsx
@@ -1,8 +1,9 @@
 import { PropsWithChildren } from "react";
 import { Link, usePage } from "@inertiajs/react";
+import type { SharedData } from "@/types";
 
 export default function AdminLayout({ children }: PropsWithChildren) {
-  const { auth } = usePage<any>().props;
+  const { auth } = usePage<SharedData>().props;
   return (
     <div className="min-h-screen bg-gray-50">
       <header className="border-b bg-white">

--- a/resources/js/pages/Run/SurveyRun.tsx
+++ b/resources/js/pages/Run/SurveyRun.tsx
@@ -5,16 +5,16 @@ import { Survey } from "survey-react-ui";
 declare function route(name: string, params?: unknown): string;
 
 type PageProps = {
-  survey: { id:number; title:string; slug:string; schema:any };
+  survey: { id: number; title: string; slug: string; schema: unknown };
   flash?: { ok?: string };
 };
 
 export default function SurveyRun() {
-  const { survey, flash } = usePage<PageProps>().props as any;
+  const { survey, flash } = usePage<PageProps>().props;
 
   const model = new Model({
     title: survey.title,
-    ...survey.schema
+    ...(survey.schema as Record<string, unknown>)
   });
   model.locale = "id";
 

--- a/resources/js/pages/Surveys/Edit.tsx
+++ b/resources/js/pages/Surveys/Edit.tsx
@@ -1,10 +1,12 @@
 import { Head, router } from "@inertiajs/react";
-import AdminLayout from "@/Layouts/AdminLayout";
+import AdminLayout from "@/layouts/AdminLayout";
 import { useMemo } from "react";
 import { SurveyCreatorComponent, SurveyCreator } from "survey-creator-react";
 import "survey-creator-core/survey-creator-core.min.css";
 
-type SurveyDTO = { id:number; title:string; schema_json:any } | null;
+declare function route(name: string, params?: unknown): string;
+
+type SurveyDTO = { id: number; title: string; schema_json: unknown } | null;
 
 export default function Edit({ survey }: { survey: SurveyDTO }) {
   const creator = useMemo<SurveyCreator>(() => {
@@ -15,7 +17,7 @@ export default function Edit({ survey }: { survey: SurveyDTO }) {
     });
     if (survey?.schema_json) c.JSON = survey.schema_json;
     return c;
-  }, [survey?.id]);
+  }, [survey?.id, survey?.schema_json]);
 
   const onSave = () => {
     const payload = {

--- a/resources/js/pages/Surveys/Index.tsx
+++ b/resources/js/pages/Surveys/Index.tsx
@@ -1,46 +1,55 @@
+import { useState } from "react";
 import { Link, Head } from "@inertiajs/react";
 import AdminLayout from "@/layouts/AdminLayout";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { SurveyCard } from "@/components/survey-card";
 
 declare function route(name: string, params?: unknown): string;
 
-type SurveyRow = { id:number; title:string; slug:string; status:"draft"|"published"; version:number; published_at?: string; created_at:string; };
+type SurveyRow = {
+  id: number;
+  title: string;
+  slug: string;
+  status: "draft" | "published";
+  version: number;
+  responses_count: number;
+  published_at?: string;
+  created_at: string;
+};
 
-export default function Index({ surveys }:{ surveys: SurveyRow[] }) {
+export default function Index({ surveys }: { surveys: SurveyRow[] }) {
+  const [query, setQuery] = useState("");
+  const filtered = surveys.filter((s) =>
+    `${s.title} ${s.slug}`.toLowerCase().includes(query.toLowerCase())
+  );
+
   return (
     <AdminLayout>
       <Head title="Surveys" />
-      <div className="mb-4 flex justify-between">
+      <div className="mb-4 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
         <h1 className="text-xl font-semibold">Surveys</h1>
-        <Link href={route('surveys.create')} className="px-3 py-2 rounded bg-blue-600 text-white">Buat Survei</Link>
+        <div className="flex w-full gap-2 sm:w-auto">
+          <Input
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Cari..."
+            className="sm:w-64"
+          />
+          <Button asChild>
+            <Link href={route("surveys.create")}>Buat Survei</Link>
+          </Button>
+        </div>
       </div>
-      <div className="bg-white rounded shadow">
-        <table className="w-full text-sm">
-          <thead className="bg-gray-100">
-            <tr>
-              <th className="p-2 text-left">Judul</th>
-              <th className="p-2">Status</th>
-              <th className="p-2">Version</th>
-              <th className="p-2">Aksi</th>
-            </tr>
-          </thead>
-          <tbody>
-            {surveys.map(s => (
-              <tr key={s.id} className="border-t">
-                <td className="p-2">{s.title}<div className="text-xs text-gray-500">/{s.slug}</div></td>
-                <td className="p-2 text-center">{s.status}</td>
-                <td className="p-2 text-center">{s.version}</td>
-                <td className="p-2 text-right space-x-2">
-                  <Link href={route('surveys.edit', s.id)} className="text-blue-600">Edit</Link>
-                  <Link href={route('surveys.responses', s.id)} className="text-green-600">Responses</Link>
-                  {s.status === 'published' && (
-                    <a href={route('run.show', s.slug)} target="_blank" className="text-gray-700 underline">Open</a>
-                  )}
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      </div>
+      {filtered.length > 0 ? (
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {filtered.map((s) => (
+            <SurveyCard key={s.id} survey={s} />
+          ))}
+        </div>
+      ) : (
+        <p className="text-sm text-muted-foreground">Tidak ada survei.</p>
+      )}
     </AdminLayout>
   );
 }

--- a/resources/js/pages/Surveys/ResponseShow.tsx
+++ b/resources/js/pages/Surveys/ResponseShow.tsx
@@ -1,7 +1,12 @@
-import AdminLayout from "@/Layouts/AdminLayout";
+import AdminLayout from "@/layouts/AdminLayout";
 import { Head } from "@inertiajs/react";
 
-export default function ResponseShow({ survey, response }: any) {
+type Props = {
+  survey: { title: string };
+  response: { response_uuid: string; submitted_at: string; answers_json: unknown };
+};
+
+export default function ResponseShow({ survey, response }: Props) {
   return (
     <AdminLayout>
       <Head title={`Response — ${survey.title}`} />

--- a/resources/js/pages/Surveys/Responses.tsx
+++ b/resources/js/pages/Surveys/Responses.tsx
@@ -1,7 +1,12 @@
-import AdminLayout from "@/Layouts/AdminLayout";
+import AdminLayout from "@/layouts/AdminLayout";
 import { Head, Link } from "@inertiajs/react";
 
-export default function Responses({ survey, responses }: any) {
+declare function route(name: string, params?: unknown): string;
+
+type ResponseRow = { id: number; response_uuid: string; submitted_at: string };
+type PageProps = { survey: { id: number; title: string }; responses: { data: ResponseRow[] } };
+
+export default function Responses({ survey, responses }: PageProps) {
   return (
     <AdminLayout>
       <Head title={`Responses — ${survey.title}`} />
@@ -22,7 +27,7 @@ export default function Responses({ survey, responses }: any) {
             </tr>
           </thead>
           <tbody>
-            {responses.data.map((r:any) => (
+            {responses.data.map((r) => (
               <tr key={r.id} className="border-t">
                 <td className="p-2">{r.response_uuid}</td>
                 <td className="p-2 text-center">{r.submitted_at}</td>


### PR DESCRIPTION
## Summary
- add SurveyCard component to show survey status, version, and response actions
- render survey index as searchable card grid
- include response counts in survey listing

## Testing
- `npm run lint`
- `npm run types` *(fails: Cannot find module '@/routes' in auth pages)*
- `php artisan test` *(fails: No application encryption key specified; multiple tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_68c031bab610833185d07216a6c1630f