### PR TITLE
refactor: simplify survey editor memo deps

### DIFF
--- a/resources/js/pages/Surveys/Edit.tsx
+++ b/resources/js/pages/Surveys/Edit.tsx
@@ -17,7 +17,7 @@ export default function Edit({ survey }: { survey: SurveyDTO }) {
     });
     if (survey?.schema_json) c.JSON = survey.schema_json;
     return c;
-  }, [survey?.id, survey?.schema_json]);
+  }, [survey?.schema_json]);
 
   const onSave = () => {
     const payload = {


### PR DESCRIPTION
## Summary
- avoid unnecessary SurveyCreator re-instantiation by removing unused survey id dependency

## Testing
- `npm run lint`
- `npm run types` *(fails: Cannot find module '@/routes' or its corresponding type declarations.)*


------
https://chatgpt.com/codex/tasks/task_e_68c04aa5656c833193363dc52f073990